### PR TITLE
linux-stable.sh: Fix detection of current kernel version if OUT is set

### DIFF
--- a/linux-stable.sh
+++ b/linux-stable.sh
@@ -189,7 +189,7 @@ function generate_versions() {
     header "Calculating versions"
 
     # Full kernel version
-    CURRENT_VERSION=$(make kernelversion)
+    CURRENT_VERSION=$(make kernelversion O=)
     # First two numbers (3.4 | 3.10 | 3.18 | 4.4)
     CURRENT_MAJOR_VERSION=$(echo "${CURRENT_VERSION}" | cut -f 1,2 -d .)
     # Last number


### PR DESCRIPTION
if OUT var is exported, then make kernelversion produces following output

```
make[1]: Entering directory '/home/user/kernel/out'
 3.18.124
make[1]: Leaving directory '/home/user/kernel/out'
```

thus resulting in failure to detect current kernel version

to fix, specify empty out path with command